### PR TITLE
using built-in querystring parsing/stringifying

### DIFF
--- a/lib/EnvProxyFactory.js
+++ b/lib/EnvProxyFactory.js
@@ -4,7 +4,14 @@ var chalk = require('chalk'),
   http  = require('http'),
   httpProxy = require('http-proxy'),
   urlParse = require('url-parse'),
-  urlPattern = require('url-pattern');
+  urlPattern = require('url-pattern'),
+  URL = require('url'),
+  querystring = require('querystring');
+
+// use node.js built-in querystring parsing
+function parse(url) {
+  return urlParse(url, url => URL.parse(url, true).query);
+}
 
 var ProxyServer = function(options) {
 
@@ -62,8 +69,8 @@ ProxyServer.prototype.buildUrls = function(req) {
       // to the target; omit the pattern itself
       var url = req.url.replace(key, '');
 
-      var parsedURL = urlParse(url, true);
-      var parsedTarget = urlParse(this.urls[key], true);
+      var parsedURL = parse(url);
+      var parsedTarget = parse(this.urls[key]);
 
       // Merge query parameters into the requested URL
       parsedURL.set('query', Object.assign(
@@ -76,8 +83,8 @@ ProxyServer.prototype.buildUrls = function(req) {
       // been merged into the requested URL
       parsedTarget.set('query', '');
 
-      var requested = parsedURL.toString();
-      var target = parsedTarget.toString();
+      var requested = parsedURL.toString(querystring.stringify);
+      var target = parsedTarget.toString(querystring.stringify);
 
       console.log(`${chalk.blue(requested)} ${chalk.yellow('=>')} ${chalk.cyan(target)}`);
 


### PR DESCRIPTION
I was seeing an issue where URL's with query strings that have repeating keys (e.g. like `/my/url?has=this&has=that` would omit the additional values when sent along to the proxied server. This seems to stem from [`querystringify`](https://github.com/unshiftio/querystringify), which stringifies/parses querystrings for the url-parse library differently from how the stdlib does things. Luckily url-parse allows you to pass in your own querystring stringifier/parser...passing in the standard URL/querystring utilities seems to "just work"!

e.g. where before the querystring parse would return `{ has: 'that' }`, it should now return `{ has: [ 'this', 'that' ] }`. Similarly, stringifying `{ has: [ 'this', 'that' ] }` produces `has=this&has=that`.